### PR TITLE
Set up NGINX / oauth2-proxy to skip validation for existing tokens an…

### DIFF
--- a/contrib/local-environment/README.md
+++ b/contrib/local-environment/README.md
@@ -1,3 +1,32 @@
-# oauth2-proxy: local-environment
+# To test run:
 
-Run `make up` to deploy local dex, etcd and oauth2-proxy instances in Docker containers. Review the [`Makefile`](Makefile) for additional deployment options.
+```bash
+$ make nginx-up
+```
+
+And now navigate to [http://httpbin.oauth2-proxy.localhost/get](http://httpbin.oauth2-proxy.localhost/get).
+If you're using Chrome, this should just work.
+If you're using another browser (or `curl`), add these entries to `/etc/hosts`:
+
+```text
+127.0.0.1 oauth2-proxy.localhost
+127.0.0.1 httpbin.oauth2-proxy.localhost
+127.0.0.1 oauth2-proxy.oauth2-proxy.localhost
+```
+
+You should be redirected to log in. The credentials are:
+
+- `username`: admin@example.com
+- `password`: password
+
+Once you log in, you'll be redirected back to the `httpbin` response, which will include an `Authorization` header that holds the JWT access token that the IdP generated.
+You can copy this token and make requests from `curl` or do other programmatic access things:
+
+```bash
+$ export MY_TOKEN="<token you copied above>"
+$ curl -H "Accept: application/json" -H "Authorization: Bearer $MY_TOKEN" -L http://httpbin.oauth2-proxy.localhost/get
+```
+
+You'll get the same JSON response as before, but without the login process.
+
+If you put an invalid token in the header, you'll get a 401.

--- a/contrib/local-environment/nginx.conf
+++ b/contrib/local-environment/nginx.conf
@@ -18,6 +18,10 @@ server {
 
   auth_request /internal-auth/oauth2/auth;
 
+  # Copy the access token from oauth2-proxy's response to the upstream request's Authorization header
+  auth_request_set $access_token $upstream_http_x_auth_request_access_token;
+  proxy_set_header Authorization "Bearer $access_token";
+
   # If the auth_request denies the request (401), redirect to the sign_in page
   # and include the final rd URL back to the user's original request.
   error_page 401 = http://oauth2-proxy.oauth2-proxy.localhost/oauth2/sign_in?rd=$scheme://$host$request_uri;

--- a/contrib/local-environment/nginx.conf
+++ b/contrib/local-environment/nginx.conf
@@ -11,6 +11,11 @@ server {
   }
 }
 
+map $http_accept $accept_header {
+    default $http_accept;
+    ""      */*;    
+}
+
 # Reverse proxy to httpbin
 server {
   listen      80;
@@ -24,10 +29,14 @@ server {
 
   # If the auth_request denies the request (401), redirect to the sign_in page
   # and include the final rd URL back to the user's original request.
-  error_page 401 = http://oauth2-proxy.oauth2-proxy.localhost/oauth2/sign_in?rd=$scheme://$host$request_uri;
-
-  # Alternatively send the request to `start` to skip the provider button
-  # error_page 401 = http://oauth2-proxy.oauth2-proxy.localhost/oauth2/start?rd=$scheme://$host$request_uri;
+  error_page 401 = @unauthorized;
+  location @unauthorized {
+    internal;
+    if ($accept_header ~* "text/html") {
+      return 302 http://oauth2-proxy.oauth2-proxy.localhost/oauth2/sign_in?rd=$scheme://$host$request_uri;
+    }
+    return 401 "Unauthorized";
+  }
 
   location / {
     proxy_pass http://httpbin/;

--- a/contrib/local-environment/oauth2-proxy-nginx.cfg
+++ b/contrib/local-environment/oauth2-proxy-nginx.cfg
@@ -10,3 +10,9 @@ cookie_secure="false"
 redirect_url="http://oauth2-proxy.oauth2-proxy.localhost/oauth2/callback"
 cookie_domains=".oauth2-proxy.localhost" # Required so cookie can be read on all subdomains.
 whitelist_domains=".oauth2-proxy.localhost" # Required to allow redirection back to original requested target.
+
+# If we get a request with a VALID Bearer token, including the right iss and aud, pass straight to upstream
+skip_jwt_bearer_tokens="true"
+# Return the access token in the response to NGINX in the X-Auth-Request-Access-Token header
+pass_access_token="true"
+set_xauthrequest="true"


### PR DESCRIPTION
Mermaid Diagram:

```mermaid
sequenceDiagram

participant client as Client
participant nginx as NGINX
participant backend as Backend
participant authproxy as Auth Proxy
participant idp as Identity Provider

    # Note over client,tasks: Can raise exception for dependency, handled after response is sent
    # Note over client,operation: Can raise HTTPException and can change the response
    client ->> nginx: Start request
    nginx ->> authproxy: Check authentication
    alt JWT in Authorization header
        alt valid JWT
            authproxy ->> nginx: 200 w/ blank response
            nginx ->> backend: Unmodified request
        end
        alt invalid JWT
            authproxy ->> nginx: 401 w/ blank response
            alt Accept: text/html
                nginx ->> client: Login redirect
                client ->> nginx: Redirect w/ valid cookie
            else
                nginx ->> client: 401
            end
        end
    end
    alt Auth Proxy Cookie
        alt valid Cookie
            authproxy ->> idp: Get access token
            authproxy ->> nginx: 200 w/ access token in X-Auth-Request-Access-Token header
            nginx ->> backend: Copy X-Auth-Request-Access-Token to Authorization: Bearer {token}
        end
        alt invalid or missing Cookie
            authproxy ->> nginx: 401 w/ blank response
            alt Accept: text/html
                nginx ->> client: Login redirect
                client ->> nginx: Redirect w/ valid cookie
            else
                nginx ->> client: 401
            end
        end
    end
```